### PR TITLE
change the hover color on the navbar name

### DIFF
--- a/Website/style/mainStyle.css
+++ b/Website/style/mainStyle.css
@@ -1,27 +1,31 @@
-body{
-    background-color: #0A192F;
-    color: #CCD6F6;
-    font-family: 'Anonymous Pro';
+body {
+  background-color: #0a192f;
+  color: #ccd6f6;
+  font-family: "Anonymous Pro";
 }
 
-.textColor{
-    color: #CCD6F6;
+.textColor {
+  color: #ccd6f6;
 }
 
-.accentColor{
-    color: #5BEAAB;
+.accentColor {
+  color: #5beaab;
 }
 
-.mainColorBg{
-    background-color: #0A192F;
+.mainColorBg {
+  background-color: #0a192f;
 }
 
-.mainColorBgBright{
-    background-color: #0c2f4b;
+.mainColorBgBright {
+  background-color: #0c2f4b;
 }
 
-.fullPage{
-    padding-top: 15%;
-    padding-bottom: 15%;
-    padding-left: 10%;
+.fullPage {
+  padding-top: 15%;
+  padding-bottom: 15%;
+  padding-left: 10%;
+}
+
+.navbar-brand:hover {
+  color: #ccd6f6;
 }


### PR DESCRIPTION
Changed the color of the `name logo` inside the `navbar` to be the same color as the text when hovered.

Below is a video of how the `name logo` will look after the fix: 


https://user-images.githubusercontent.com/94648837/192745305-f99eb281-da99-465e-b65a-fc4dab0c95b4.mov

